### PR TITLE
Fix 1 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
  <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version> 2.10.5.1</version>  
+      <version>2.9.5</version>  
     </dependency> 
     <dependency>  
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Thu, 28 Oct 2021 08:38:19 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-7489](https://nvd.nist.gov/vuln/detail/CVE-2018-7489) | 9.8 | fixed in 2.9.5, 2.8.11.1, 2.7.9.3 | FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.
